### PR TITLE
typo fix?

### DIFF
--- a/pystellibs/stellib.py
+++ b/pystellibs/stellib.py
@@ -226,8 +226,8 @@ class Stellib(object):
 
         logZ = np.log10(Z)
         aps = np.array([logT, logg, logZ]).T
-        s = self.interpolator.interp(aps) * weights[:, None]
-        specs[bound] = s[bound]
+        s = self.interpolator.interp(aps[bound]) * weights[bound, None]
+        specs[bound] = s
 
         l0 = self.wavelength
         specs = specs * self.flux_units

--- a/pystellibs/stellib.py
+++ b/pystellibs/stellib.py
@@ -227,7 +227,7 @@ class Stellib(object):
         logZ = np.log10(Z)
         aps = np.array([logT, logg, logZ]).T
         s = self.interpolator.interp(aps) * weights[:, None]
-        specs[bound] = s
+        specs[bound] = s[bound]
 
         l0 = self.wavelength
         specs = specs * self.flux_units


### PR DESCRIPTION
`generate_individual_spectra` broke for me (shape mismatch) without this.